### PR TITLE
devices: Drop support for HammerheadCaf and Otus

### DIFF
--- a/aoscp.devices
+++ b/aoscp.devices
@@ -9,7 +9,6 @@ flo
 h815
 h811
 hammerhead
-hammerheadcaf
 kenzo
 ls990
 mako
@@ -17,7 +16,6 @@ m8
 oneplus2
 oneplus3
 osprey
-otus
 pme
 shamu
 surnia


### PR DESCRIPTION
We'll stick with AOSP Hammerhead for now and otus generates
too many issues. We'll let a maintainer pick that device up
if they choose to do so

Change-Id: I3024e0f6d406f018ed18d1bbb49d59cca42162a7